### PR TITLE
Update ProductInstanceProps.tsx

### DIFF
--- a/src/components/entities/product/ProductInstanceProps.tsx
+++ b/src/components/entities/product/ProductInstanceProps.tsx
@@ -130,14 +130,19 @@ class ProductInstanceProps extends React.Component<Props, State> {
   };
 
   deleteButtonActive = () => {
+    if (this.props.hasRole(Roles.ADMIN)) {
+      return true;
+    }
+
     if (this.props.create) {
       return undefined;
     }
-    return !(this.props.contract.activities
-      .filter((a) => a.type === ActivityType.STATUS).length > 1
-      || this.props.productInstance.activities
-        .filter((a) => a.type === ActivityType.STATUS).length > 1
-      || this.props.productInstance.invoiceId === undefined);
+    const status = getLastStatus(this.props.contract.activities
+      .filter((a) => a.type === ActivityType.STATUS));
+    return !(status!.subType === ContractStatus.CONFIRMED
+      || status!.subType === ContractStatus.FINISHED
+      || status!.subType === ContractStatus.CANCELLED
+      || this.props.productInstance.invoiceId !== undefined);
   };
 
   editButtonActive = () => {


### PR DESCRIPTION
In my opinion, the user should still be able to delete products from the contract when it is not yet signed. Even when I have sent a contract, changes might happen. These changes are not reflected in the pricing which makes life way harder as you have to calculate prices yourself and the product looks "cancelled".

FIY, please check whether this is correct in the code as I basically copied and pasted the editing handler