### PR TITLE
Update Docker registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Login to container registry
         uses: docker/login-action@v2
         with:
-          registry: parelpracht.docker-registry.gewis.nl
+          registry: abc.docker-registry.gewis.nl
           username: ${{ secrets.SVC_GH_PARELPRACHT_USERNAME }}
           password: ${{ secrets.SVC_GH_PARELPRACHT_PWD }}
       - name: Build and push
@@ -21,5 +21,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: parelpracht.docker-registry.gewis.nl/parelpracht-client:latest
+          tags: abc.docker-registry.gewis.nl/crm/parelpracht/client:latest
           no-cache: true


### PR DESCRIPTION
Updates the Docker registry to the central ABC registry. The additional `/` between `parelpracht` and `client` makes it possible to make a distinction between the project (`parelpracht`) and the service (`client`).