### PR TITLE
fix: fix broken status filter on the contracts and invoices page

### DIFF
--- a/src/components/entities/invoice/InvoiceTable.tsx
+++ b/src/components/entities/invoice/InvoiceTable.tsx
@@ -46,17 +46,16 @@ interface Props {
 }
 
 function InvoicesTable({
-  invoices, column, direction, changeSort, setSort,
+  invoices, fetchInvoices, column, direction, changeSort, setSort, setTableFilter,
   total, fetched, skip, take, status,
-  prevPage, nextPage, setTake,
+  prevPage, nextPage, setTake, hasRole,
 }: Props) {
   const { t } = useTranslation();
 
   useEffect(() => {
     setSort('id', 'DESC');
-    // TODO: Fix status filtering in backend
-    // if (([Roles.FINANCIAL].some(hasRole) && ![Roles.ADMIN].some(hasRole))) setTableFilter({ column: 'activityStatus', values: ['SENT'] });
-    // fetchInvoices();
+    if (([Roles.FINANCIAL].some(hasRole) && ![Roles.ADMIN].some(hasRole))) setTableFilter({ column: 'activityStatus', values: ['SENT'] });
+    fetchInvoices();
   }, []);
 
   const table = (

--- a/src/components/tablefilters/ContractStatusFilter.tsx
+++ b/src/components/tablefilters/ContractStatusFilter.tsx
@@ -15,9 +15,6 @@ function ContractStatusFilter(props: Props) {
     return { key: i, value: s, text: formatStatus(s) };
   });
 
-  // TODO: Fix status filtering in the backend
-  return null;
-
   return (
     <ColumnFilter
       column={props.column!}
@@ -29,7 +26,7 @@ function ContractStatusFilter(props: Props) {
 }
 
 ContractStatusFilter.defaultProps = {
-  column: 'activityStatus',
+  column: 'activities.subType',
   columnName: 'Status',
   table: Tables.Contracts,
 };

--- a/src/components/tablefilters/InvoiceStatusFilter.tsx
+++ b/src/components/tablefilters/InvoiceStatusFilter.tsx
@@ -9,12 +9,9 @@ function InvoiceStatusFilter() {
     return { key: i, value: s, text: formatStatus(s) };
   });
 
-  // TODO: Fix status filtering in the backend
-  return null;
-
   return (
     <ColumnFilter
-      column="activityStatus"
+      column="activities.subType"
       columnName="Status"
       table={Tables.Invoices}
       options={options}


### PR DESCRIPTION


# Description
This pull request reverts commit fa8428c2. This is made possible by [GEWIS/parelpracht-server#35](https://github.com/GEWIS/parelpracht-server/pull/35). The status filters on the contract and invoices pages are now usable again.


## Types of changes
- Bug fix 