### PR TITLE
ci: fix lint-and-build by enabling Corepack before yarn cache

### DIFF
--- a/.github/workflows/lint-and-build-client.yaml
+++ b/.github/workflows/lint-and-build-client.yaml
@@ -15,6 +15,7 @@ jobs:
     uses: GEWIS/actions/.github/workflows/lint-and-build-yarn.yml@v1
     with:
       node-version: '20.x'
+      prepare-command: corepack enable
       lint: true
       format: true
       build: true

--- a/.github/workflows/lint-and-build-server.yaml
+++ b/.github/workflows/lint-and-build-server.yaml
@@ -15,6 +15,7 @@ jobs:
     uses: GEWIS/actions/.github/workflows/lint-and-build-yarn.yml@v1
     with:
       node-version: "22.x"
+      prepare-command: corepack enable
       lint: true
       format: true
       build: true


### PR DESCRIPTION
## Problem

Every `Lint and build (client/server)` run fails at the **Set Node.js** step:

```
error This project's package.json defines "packageManager": "yarn@4.5.1".
However the current global version of Yarn is 1.22.22.
... Corepack must currently be enabled by running corepack enable ...
```

The GEWIS reusable workflow `lint-and-build-yarn.yml` runs `actions/setup-node` with `cache: 'yarn'` — which calls `yarn cache dir` using the runner's global yarn 1.x — **before** its own `Enable Corepack` step. Since both workspaces are pinned to yarn 4 via the `packageManager` field, yarn 1.x aborts and the job dies before installing anything. (`v1` and `v1.15.0` of the reusable workflow point at the same commit, so a version bump doesn't help.)

## Fix

The reusable workflow has a `prepare-command` input that runs **before** `setup-node`. Setting it to `corepack enable` means the cache lookup resolves the corepack-managed yarn 4 instead of global yarn 1.x.

Applied to both `lint-and-build-client.yaml` and `lint-and-build-server.yaml`.

Verified by this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)